### PR TITLE
Fix rescore named queries review

### DIFF
--- a/server/src/main/java/org/opensearch/search/dfs/DfsPhase.java
+++ b/server/src/main/java/org/opensearch/search/dfs/DfsPhase.java
@@ -86,8 +86,8 @@ public class DfsPhase {
 
             searcher.createWeight(context.searcher().rewrite(context.query()), ScoreMode.COMPLETE, 1);
             for (RescoreContext rescoreContext : context.rescore()) {
-                for (Query query : rescoreContext.getQueries()) {
-                    searcher.createWeight(context.searcher().rewrite(query), ScoreMode.COMPLETE, 1);
+                for (org.opensearch.index.query.ParsedQuery parsedQuery : rescoreContext.getParsedQueries()) {
+                    searcher.createWeight(context.searcher().rewrite(parsedQuery.query()), ScoreMode.COMPLETE, 1);
                 }
             }
 

--- a/server/src/main/java/org/opensearch/search/fetch/subphase/MatchedQueriesPhase.java
+++ b/server/src/main/java/org/opensearch/search/fetch/subphase/MatchedQueriesPhase.java
@@ -42,7 +42,6 @@ import org.opensearch.search.fetch.FetchContext;
 import org.opensearch.search.fetch.FetchSubPhase;
 import org.opensearch.search.fetch.FetchSubPhaseProcessor;
 import org.opensearch.search.rescore.RescoreContext;
-import org.opensearch.search.rescore.QueryRescorer;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -69,11 +68,8 @@ public final class MatchedQueriesPhase implements FetchSubPhase {
         }
         if (context.rescore() != null) {
             for (RescoreContext rescoreContext : context.rescore()) {
-                if (rescoreContext instanceof QueryRescorer.QueryRescoreContext) {
-                    QueryRescorer.QueryRescoreContext queryRescoreContext = (QueryRescorer.QueryRescoreContext) rescoreContext;
-                    if (queryRescoreContext.parsedQuery() != null) {
-                        namedQueries.putAll(queryRescoreContext.parsedQuery().namedFilters());
-                    }
+                if (rescoreContext.parsedQuery() != null) {
+                    namedQueries.putAll(rescoreContext.parsedQuery().namedFilters());
                 }
             }
         }

--- a/server/src/main/java/org/opensearch/search/rescore/QueryRescorer.java
+++ b/server/src/main/java/org/opensearch/search/rescore/QueryRescorer.java
@@ -69,7 +69,7 @@ public final class QueryRescorer implements Rescorer {
 
         final QueryRescoreContext rescore = (QueryRescoreContext) rescoreContext;
 
-        org.apache.lucene.search.Rescorer rescorer = new org.apache.lucene.search.QueryRescorer(rescore.query()) {
+        org.apache.lucene.search.Rescorer rescorer = new org.apache.lucene.search.QueryRescorer(rescore.parsedQuery().query()) {
 
             @Override
             protected float combine(float firstPassScore, boolean secondPassMatches, float secondPassScore) {
@@ -122,7 +122,7 @@ public final class QueryRescorer implements Rescorer {
             prim = Explanation.noMatch("First pass did not match", sourceExplanation);
         }
         if (rescoreContext.isRescored(topLevelDocId)) {
-            Explanation rescoreExplain = searcher.explain(rescore.query(), topLevelDocId);
+            Explanation rescoreExplain = searcher.explain(rescore.parsedQuery().query(), topLevelDocId);
             // NOTE: we don't use Lucene's Rescorer.explain because we want to insert our own description with which ScoreMode was used.
             // Maybe we should add QueryRescorer.explainCombine to Lucene?
             if (rescoreExplain != null && rescoreExplain.isMatch()) {
@@ -212,17 +212,8 @@ public final class QueryRescorer implements Rescorer {
         }
 
         @Override
-        public List<Query> getQueries() {
-            return Collections.singletonList(query());
-        }
-
-        @Override
         public List<org.opensearch.index.query.ParsedQuery> getParsedQueries() {
             return parsedQuery != null ? Collections.singletonList(parsedQuery) : Collections.emptyList();
-        }
-
-        public Query query() {
-            return parsedQuery != null ? parsedQuery.query() : null;
         }
 
         public float queryWeight() {

--- a/server/src/main/java/org/opensearch/search/rescore/QueryRescorer.java
+++ b/server/src/main/java/org/opensearch/search/rescore/QueryRescorer.java
@@ -206,6 +206,7 @@ public final class QueryRescorer implements Rescorer {
             this.parsedQuery = parsedQuery;
         }
 
+        @Override
         public org.opensearch.index.query.ParsedQuery parsedQuery() {
             return parsedQuery;
         }
@@ -213,6 +214,11 @@ public final class QueryRescorer implements Rescorer {
         @Override
         public List<Query> getQueries() {
             return Collections.singletonList(query());
+        }
+
+        @Override
+        public List<org.opensearch.index.query.ParsedQuery> getParsedQueries() {
+            return parsedQuery != null ? Collections.singletonList(parsedQuery) : Collections.emptyList();
         }
 
         public Query query() {

--- a/server/src/main/java/org/opensearch/search/rescore/QueryRescorerBuilder.java
+++ b/server/src/main/java/org/opensearch/search/rescore/QueryRescorerBuilder.java
@@ -193,8 +193,7 @@ public class QueryRescorerBuilder extends RescorerBuilder<QueryRescorerBuilder> 
     public QueryRescoreContext innerBuildContext(int windowSize, QueryShardContext context) throws IOException {
         QueryRescoreContext queryRescoreContext = new QueryRescoreContext(windowSize);
 
-        ParsedQuery parsedQuery = context.toQuery(queryBuilder);
-        queryRescoreContext.setParsedQuery(parsedQuery);
+        queryRescoreContext.setParsedQuery(context.toQuery(queryBuilder));
 
         queryRescoreContext.setQueryWeight(this.queryWeight);
         queryRescoreContext.setRescoreQueryWeight(this.rescoreQueryWeight);

--- a/server/src/main/java/org/opensearch/search/rescore/RescoreContext.java
+++ b/server/src/main/java/org/opensearch/search/rescore/RescoreContext.java
@@ -34,6 +34,7 @@ package org.opensearch.search.rescore;
 
 import org.apache.lucene.search.Query;
 import org.opensearch.common.annotation.PublicApi;
+import org.opensearch.index.query.ParsedQuery;
 
 import java.util.Collections;
 import java.util.List;
@@ -88,9 +89,23 @@ public class RescoreContext {
     }
 
     /**
+     * Returns the parsed query for this rescore context, or null if not applicable
+     */
+    public ParsedQuery parsedQuery() {
+        return null;
+    }
+
+    /**
      * Returns queries associated with the rescorer
      */
     public List<Query> getQueries() {
+        return Collections.emptyList();
+    }
+
+    /**
+     * Returns parsed queries associated with the rescorer
+     */
+    public List<ParsedQuery> getParsedQueries() {
         return Collections.emptyList();
     }
 }

--- a/server/src/main/java/org/opensearch/search/rescore/RescoreContext.java
+++ b/server/src/main/java/org/opensearch/search/rescore/RescoreContext.java
@@ -96,13 +96,6 @@ public class RescoreContext {
     }
 
     /**
-     * Returns queries associated with the rescorer
-     */
-    public List<Query> getQueries() {
-        return Collections.emptyList();
-    }
-
-    /**
      * Returns parsed queries associated with the rescorer
      */
     public List<ParsedQuery> getParsedQueries() {

--- a/server/src/test/java/org/opensearch/search/rescore/QueryRescorerBuilderTests.java
+++ b/server/src/test/java/org/opensearch/search/rescore/QueryRescorerBuilderTests.java
@@ -190,7 +190,7 @@ public class QueryRescorerBuilderTests extends OpenSearchTestCase {
                 : rescoreBuilder.windowSize().intValue();
             assertEquals(expectedWindowSize, rescoreContext.getWindowSize());
             Query expectedQuery = Rewriteable.rewrite(rescoreBuilder.getRescoreQuery(), mockShardContext).toQuery(mockShardContext);
-            assertEquals(expectedQuery, rescoreContext.query());
+            assertEquals(expectedQuery, rescoreContext.parsedQuery().query());
             assertEquals(rescoreBuilder.getQueryWeight(), rescoreContext.queryWeight(), Float.MIN_VALUE);
             assertEquals(rescoreBuilder.getRescoreQueryWeight(), rescoreContext.rescoreQueryWeight(), Float.MIN_VALUE);
             assertEquals(rescoreBuilder.getScoreMode(), rescoreContext.scoreMode());


### PR DESCRIPTION
Complete interface replacement: replace query() with parsedQuery() and getQueries() with getParsedQueries()

- Removed query() method from QueryRescoreContext  
- Removed getQueries() method from RescoreContext interface
- Updated all callers to use parsedQuery().query() instead of query()
- Updated DfsPhase to use getParsedQueries() instead of getQueries()
- Updated QueryRescorer to use parsedQuery().query() for rescoring and explanations
- Updated QueryRescorerBuilderTests to use parsedQuery().query()